### PR TITLE
FIX Issue 44: Warning for empty data sources missing information

### DIFF
--- a/vlog4j-core/src/main/java/org/semanticweb/vlog4j/core/reasoner/implementation/VLogReasoner.java
+++ b/vlog4j-core/src/main/java/org/semanticweb/vlog4j/core/reasoner/implementation/VLogReasoner.java
@@ -228,7 +228,7 @@ public class VLogReasoner implements Reasoner {
 				throw new RuntimeException("Inconsistent reasoner state.", e);
 			}
 			if (dataSourcePredicateArity == -1) {
-				LOGGER.warn("Data source {0} for predicate {1} is empty: ", this.dataSourceForPredicate.get(predicate),
+				LOGGER.warn("Data source {} for predicate {} is empty: ", this.dataSourceForPredicate.get(predicate),
 						predicate);
 			} else if (predicate.getArity() != dataSourcePredicateArity) {
 				throw new IncompatiblePredicateArityException(predicate, dataSourcePredicateArity,


### PR DESCRIPTION
BUG: If an empty file is used as a data source, the logger warning
states "Data source {0} for predicate {1} is empty: " instead of naming
the data source and the predicate.
FIX: replace {0} and {1} with {}, which is expected by sl4j