### PR TITLE
26 exception using closed reasoner

### DIFF
--- a/vlog4j-core/src/main/java/org/semanticweb/vlog4j/core/reasoner/Reasoner.java
+++ b/vlog4j-core/src/main/java/org/semanticweb/vlog4j/core/reasoner/Reasoner.java
@@ -173,8 +173,9 @@ public interface Reasoner extends AutoCloseable {
 	 *
 	 * @param logLevel
 	 *            the logging level to be set for VLog C++ resource.
+	 * @throws ReasonerStateException if the method is called on a closed reasoner.
 	 */
-	void setLogLevel(@NonNull LogLevel logLevel);
+	void setLogLevel(@NonNull LogLevel logLevel) throws ReasonerStateException;
 
 	/**
 	 * Returns the logging level of the internal VLog C++ resource. If no value has
@@ -194,8 +195,9 @@ public interface Reasoner extends AutoCloseable {
 	 *            the file for the internal VLog C++ resource to log to. If
 	 *            {@code null} or an invalid file path, the reasoner will log to the
 	 *            default system output.
+	 * @throws ReasonerStateException if the method is called on a closed reasoner.
 	 */
-	void setLogFile(@Nullable String filePath);
+	void setLogFile(@Nullable String filePath) throws ReasonerStateException;
 
 	/**
 	 * Adds rules to the reasoner <b>knowledge base</b> in the given order. After
@@ -322,10 +324,11 @@ public interface Reasoner extends AutoCloseable {
 	 *             source ({@link #addFactsFromDataSource(Predicate, DataSource)})
 	 *             does nor match the arity of the facts in the corresponding data
 	 *             source.
+	 * @throws ReasonerStateException if the method is called on a closed reasoner.
 	 */
 	// FIXME should EdbIdbSeparationException be thrown when users try to add
 	// facts/rules?
-	void load() throws IOException, EdbIdbSeparationException, IncompatiblePredicateArityException;
+	void load() throws IOException, EdbIdbSeparationException, IncompatiblePredicateArityException, ReasonerStateException;
 
 	/**
 	 * Performs reasoning on the loaded <b>knowledge base</b>, depending on the set
@@ -358,7 +361,7 @@ public interface Reasoner extends AutoCloseable {
 	 * @throws IOException
 	 *             if I/O exceptions occur during reasoning.
 	 * @throws ReasonerStateException
-	 *             if this method is called before loading ({@link Reasoner#load()}.
+	 *             if this method is called before loading ({@link Reasoner#load()} or after closing ({@link Reasoner#close()}).
 	 */
 	boolean reason() throws IOException, ReasonerStateException;
 
@@ -396,7 +399,7 @@ public interface Reasoner extends AutoCloseable {
 	 * @return an {@link AutoCloseable} iterator for {@link QueryResult}s,
 	 *         representing distinct answers to the query.
 	 * @throws ReasonerStateException   if this method is called before loading
-	 *                                  ({@link Reasoner#load()}.
+	 *                                  ({@link Reasoner#load()} or after closing ({@link Reasoner#close()}).
 	 * @throws IllegalArgumentException if the given {@code queryAtom} contains
 	 *                                  terms ({@link Atom#getTerms()}) which are
 	 *                                  not of type {@link TermType#CONSTANT} or
@@ -441,7 +444,7 @@ public interface Reasoner extends AutoCloseable {
 	 *                      (representing named individuals).
 	 *
 	 * @throws ReasonerStateException   if this method is called before loading
-	 *                                  ({@link Reasoner#load()}.
+	 *                                  ({@link Reasoner#load()} or after closing ({@link Reasoner#close()}).
 	 * @throws IOException              if an I/O error occurs regarding given file
 	 *                                  ({@code csvFilePath)}.
 	 * @throws IllegalArgumentException
@@ -463,8 +466,9 @@ public interface Reasoner extends AutoCloseable {
 	 * {@link #load()} method). All facts inferred by reasoning are discarded. Rules
 	 * and facts added to the reasoner need to be loaded again, to be able to
 	 * perform querying and reasoning.
+	 * @throws ReasonerStateException if the method is called on a closed reasoner.
 	 */
-	void resetReasoner();
+	void resetReasoner() throws ReasonerStateException;
 
 	// TODO Map<Predicate,DataSource> exportDBToDir(File location);
 

--- a/vlog4j-core/src/main/java/org/semanticweb/vlog4j/core/reasoner/ReasonerState.java
+++ b/vlog4j-core/src/main/java/org/semanticweb/vlog4j/core/reasoner/ReasonerState.java
@@ -50,7 +50,15 @@ public enum ReasonerState {
 	 * adding rules, fact and fact data sources and setting the rule re-writing
 	 * strategy are not allowed in this state.
 	 */
-	AFTER_REASONING("completed reasoning");
+	AFTER_REASONING("completed reasoning"),
+	/**
+	 * State a Reasoner is in after method {@link Reasoner#close()} has been called.
+	 * The Reasoner cannot reason again, once it reached this state.
+	 * Loading and setting the reasoning algorithm in this state are ineffective.
+	 * Reasoning, adding rules, fact and fact data sources and setting the rule re-writing
+	 * strategy are not allowed in this state. 
+	 */
+	AFTER_CLOSING("closed");
 
 	private final String name;
 

--- a/vlog4j-core/src/main/java/org/semanticweb/vlog4j/core/reasoner/implementation/VLogReasoner.java
+++ b/vlog4j-core/src/main/java/org/semanticweb/vlog4j/core/reasoner/implementation/VLogReasoner.java
@@ -117,7 +117,7 @@ public class VLogReasoner implements Reasoner {
 		Validate.noNullElements(rules, "Null rules are not alowed! The list contains a null at position [%d].");
 		this.rules.addAll(new ArrayList<>(rules));
 		if (reasonerState.equals(ReasonerState.AFTER_CLOSING))
-			LOGGER.warn("Adding rules ot a closed reasoner.");
+			LOGGER.warn("Adding rules to a closed reasoner.");
 	}
 
 	@Override

--- a/vlog4j-core/src/test/java/org/semanticweb/vlog4j/core/reasoner/LoggingTest.java
+++ b/vlog4j-core/src/test/java/org/semanticweb/vlog4j/core/reasoner/LoggingTest.java
@@ -90,7 +90,7 @@ public class LoggingTest {
 	}
 
 	@Test(expected = NullPointerException.class)
-	public void testSetLogLevelNull() {
+	public void testSetLogLevelNull() throws ReasonerStateException {
 		try (final Reasoner instance = Reasoner.getInstance()) {
 			instance.setLogLevel(null);
 		}

--- a/vlog4j-core/src/test/java/org/semanticweb/vlog4j/core/reasoner/implementation/ReasonerStateTest.java
+++ b/vlog4j-core/src/test/java/org/semanticweb/vlog4j/core/reasoner/implementation/ReasonerStateTest.java
@@ -123,7 +123,7 @@ public class ReasonerStateTest {
 	}
 
 	@Test
-	public void testResetBeforeLoad() {
+	public void testResetBeforeLoad() throws ReasonerStateException {
 		try (final Reasoner reasoner = Reasoner.getInstance()) {
 			reasoner.resetReasoner();
 		}
@@ -286,7 +286,7 @@ public class ReasonerStateTest {
 	}
 
 	@Test
-	public void testSuccessiveCloseAfterLoad() throws EdbIdbSeparationException, IOException, IncompatiblePredicateArityException {
+	public void testSuccessiveCloseAfterLoad() throws EdbIdbSeparationException, IOException, IncompatiblePredicateArityException, ReasonerStateException {
 		try (final Reasoner reasoner = Reasoner.getInstance()) {
 			reasoner.load();
 			reasoner.close();

--- a/vlog4j-core/src/test/java/org/semanticweb/vlog4j/core/reasoner/implementation/ReasonerTest.java
+++ b/vlog4j-core/src/test/java/org/semanticweb/vlog4j/core/reasoner/implementation/ReasonerTest.java
@@ -46,7 +46,7 @@ import karmaresearch.vlog.EDBConfigurationException;
 public class ReasonerTest {
 
 	@Test
-	public void testCloseRepeatedly() throws EdbIdbSeparationException, IOException, IncompatiblePredicateArityException {
+	public void testCloseRepeatedly() throws EdbIdbSeparationException, IOException, IncompatiblePredicateArityException, ReasonerStateException {
 		try (final VLogReasoner reasoner = new VLogReasoner()) {
 			reasoner.close();
 		}


### PR DESCRIPTION
Implemented [issue 26](https://github.com/knowsys/vlog4j/issues/26).

Added `AFTER_CLOSING` state to _**ReasonerState**_.
Added **_ReasonerStateExceptions_** being thrown on _**Reasoner**_ (and subsequently _**VLogReasoner**_) public calls accessing the **_VLog_** class.
Added warnings on public calls except getters if called after `Reasoner.close()`.

Added `throws` declarations on unit tests where necessary.