### PR TITLE
64 examples add graal import usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
 		<maven.javadoc.version>3.0.0</maven.javadoc.version>
 		<owlapi.version>4.5.1</owlapi.version>
 		<openrdf.sesame.version>2.7.16</openrdf.sesame.version>
+		<graal.version>1.3.1</graal.version>
 	</properties>
 
 	<dependencies>

--- a/vlog4j-examples/pom.xml
+++ b/vlog4j-examples/pom.xml
@@ -54,6 +54,11 @@
 			<version>2.7.16</version>
 		</dependency>
 		
+		<dependency>
+			<groupId>fr.lirmm.graphik</groupId>
+			<artifactId>graal-api</artifactId>
+			<version>1.3.1</version>
+		</dependency>
     	<dependency>
       		<groupId>fr.lirmm.graphik</groupId>
       		<artifactId>graal-io-dlgp</artifactId>

--- a/vlog4j-examples/pom.xml
+++ b/vlog4j-examples/pom.xml
@@ -57,12 +57,12 @@
 		<dependency>
 			<groupId>fr.lirmm.graphik</groupId>
 			<artifactId>graal-api</artifactId>
-			<version>1.3.1</version>
+			<version>${graal.version}</version>
 		</dependency>
     	<dependency>
       		<groupId>fr.lirmm.graphik</groupId>
       		<artifactId>graal-io-dlgp</artifactId>
-      		<version>1.3.1</version>
+      		<version>${graal.version}</version>
     	</dependency>		
 	</dependencies>
 </project>

--- a/vlog4j-examples/pom.xml
+++ b/vlog4j-examples/pom.xml
@@ -53,12 +53,7 @@
 			<!-- version compatible with the org.openrdf.model version, as imported by vlog4j-rdf dependency -->
 			<version>2.7.16</version>
 		</dependency>
-		
-		<dependency>
-			<groupId>fr.lirmm.graphik</groupId>
-			<artifactId>graal-api</artifactId>
-			<version>${graal.version}</version>
-		</dependency>
+
     	<dependency>
       		<groupId>fr.lirmm.graphik</groupId>
       		<artifactId>graal-io-dlgp</artifactId>

--- a/vlog4j-examples/pom.xml
+++ b/vlog4j-examples/pom.xml
@@ -32,6 +32,11 @@
 			<artifactId>vlog4j-rdf</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>vlog4j-graal</artifactId>
+			<version>${project.version}</version>
+		</dependency>
 		
 		<dependency>
 			<!-- Rio parser and writer implementation for the Turtle file format. -->
@@ -49,7 +54,11 @@
 			<version>2.7.16</version>
 		</dependency>
 		
-		
+    	<dependency>
+      		<groupId>fr.lirmm.graphik</groupId>
+      		<artifactId>graal-io-dlgp</artifactId>
+      		<version>1.3.1</version>
+    	</dependency>		
 	</dependencies>
 </project>
 

--- a/vlog4j-examples/src/main/data/input/graal/example.dlgp
+++ b/vlog4j-examples/src/main/data/input/graal/example.dlgp
@@ -1,0 +1,28 @@
+@facts
+bicycleEDB(redBike).
+bicycleEDB(blueBike).
+bicycleEDB(blackBike).
+
+wheelEDB(redWheel).
+wheelEDB(blueWheel).
+wheelEDB(greyWheel).
+
+hasPartEDB(redBike, redWheel).
+hasPartEDB(blueBike, blueWheel).
+
+@rules
+% Importing from external database predicates
+bicycleIDB(X) :- bicycleEDB(X).
+wheelIDB(X) :- wheelEDB(X).
+hasPartIDB(X, Y) :- hasPartEDB(X, Y).
+
+% Existential rules
+hasPartIDB(X, Y), wheelIDB(Y) :- bicycleIDB(X).
+isPartOfIDB(X, Y) :- wheelIDB(X).
+
+% Inverse relationships
+isPartOfIDB(X, Y) :- hasPartIDB(Y, X).
+hasPartIDB(X, Y) :- isPartOfIDB(Y, X).
+
+@queries
+?(B, W) :- bicycleIDB(B), wheelIDB(W), isPartOfIDB(W, B).

--- a/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/graal/AddDataFromDlgpFile.java
+++ b/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/graal/AddDataFromDlgpFile.java
@@ -21,8 +21,8 @@ import fr.lirmm.graphik.graal.api.core.Rule;
 import fr.lirmm.graphik.graal.io.dlp.DlgpParser;
 
 /**
- * This example shows how facts can be imported from files in the DLGP/DLP
- * format.
+ * This example shows how facts can be imported from files in the
+ * <a href="http://graphik-team.github.io/graal/doc/dlgp">DLGP/DLP</a> format.
  * 
  * The Graal {@link DlgpParser} is used to parse the program. This step requires
  * a {@link File}, {@link InputStream}, {@link Reader}, or {@link String}

--- a/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/graal/AddDataFromDlgpFile.java
+++ b/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/graal/AddDataFromDlgpFile.java
@@ -1,0 +1,108 @@
+package org.semanticweb.vlog4j.examples.graal;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.semanticweb.vlog4j.core.reasoner.Reasoner;
+import org.semanticweb.vlog4j.core.reasoner.exceptions.EdbIdbSeparationException;
+import org.semanticweb.vlog4j.core.reasoner.exceptions.IncompatiblePredicateArityException;
+import org.semanticweb.vlog4j.core.reasoner.exceptions.ReasonerStateException;
+import org.semanticweb.vlog4j.examples.ExamplesUtils;
+import org.semanticweb.vlog4j.graal.GraalConjunctiveQueryToRule;
+import org.semanticweb.vlog4j.graal.GraalToVLog4JModelConverter;
+
+import fr.lirmm.graphik.graal.api.core.Atom;
+import fr.lirmm.graphik.graal.api.core.ConjunctiveQuery;
+import fr.lirmm.graphik.graal.api.core.Rule;
+import fr.lirmm.graphik.graal.io.dlp.DlgpParser;
+
+/**
+ * This example shows how facts can be imported from files in the DLGP/DLP
+ * format.
+ * 
+ * The Graal {@link DlgpParser} is used to parse the program. This step requires
+ * a {@link File}, {@link InputStream}, {@link Reader}, or {@link String}
+ * containing or pointing to the program.
+ * 
+ * The {@link Atom Atoms}, {@link Rule Rules}, and {@link ConjunctiveQuery
+ * ConjunctiveQueries} are then converted for use by VLog4J. Take care to add
+ * the rules resulting from the {@link ConjunctiveQuery ConjunctiveQueries} as
+ * well as the {@link Rule Rules} to the {@link Reasoner}; see
+ * {@link GraalConjunctiveQueryToRule} for details.
+ *
+ * @author Adrian Bielefeldt
+ *
+ */
+public class AddDataFromDlgpFile {
+
+	public static void main(final String[] args) throws EdbIdbSeparationException, IOException, ReasonerStateException, IncompatiblePredicateArityException {
+		
+		final List<fr.lirmm.graphik.graal.api.core.Atom> graalAtoms = new ArrayList<>();
+		final List<fr.lirmm.graphik.graal.api.core.Rule> graalRules = new ArrayList<>();
+		final List<ConjunctiveQuery> graalConjunctiveQueries = new ArrayList<>();
+
+		/*
+		 * 1. Parse the DLGP/DLP file using the DlgpParser.
+		 * 
+		 * DlgpParser supports Files, InputStreams, Readers, and Strings. While other
+		 * objects such as prefixes can also be part of the iterator, they are
+		 * automatically resolved and do not need to be handled here.
+		 */
+		try (final DlgpParser parser = new DlgpParser(new File("src/main/data/input/graal/", "example.dlgp"))) {
+			while (parser.hasNext()) {
+				final Object object = parser.next();
+				if (object instanceof Atom) {
+					graalAtoms.add((Atom) object);
+				} else if (object instanceof Rule) {
+					graalRules.add((Rule) object);
+				} else if (object instanceof ConjunctiveQuery) {
+					graalConjunctiveQueries.add((ConjunctiveQuery) object);
+				}
+			}
+		}
+
+		/*
+		 * 2. ConjunctiveQueries consist of a conjunction of atoms and a set of answer
+		 * variables. To query this with VLog4J, an additional rule needs to be added
+		 * for each ConjunctiveQuery. See GraalConjunctiveQueryToRule for details.
+		 */
+		final List<GraalConjunctiveQueryToRule> convertedConjunctiveQueries = new ArrayList<>();
+
+		int queryCount = 0;
+		for (final ConjunctiveQuery conjunctiveQuery : graalConjunctiveQueries) {
+			convertedConjunctiveQueries
+					.add(GraalToVLog4JModelConverter.convertQuery("query" + queryCount, conjunctiveQuery));
+			queryCount++;
+		}
+
+		/*
+		 * 3. Loading, reasoning, and querying while using try-with-resources to close
+		 * the reasoner automatically.
+		 */
+		try (Reasoner reasoner = Reasoner.getInstance()) {
+			reasoner.addRules(GraalToVLog4JModelConverter.convertRules(graalRules));
+			reasoner.addFacts(GraalToVLog4JModelConverter.convertAtoms(graalAtoms));
+			for (final GraalConjunctiveQueryToRule graalConjunctiveQueryToRule : convertedConjunctiveQueries) {
+				reasoner.addRules(graalConjunctiveQueryToRule.getRule());
+			}
+
+			reasoner.load();
+			System.out.println("Before materialisation:");
+			for (final GraalConjunctiveQueryToRule graalConjunctiveQueryToRule : convertedConjunctiveQueries) {
+				ExamplesUtils.printOutQueryAnswers(graalConjunctiveQueryToRule.getQueryAtom(), reasoner);
+			}
+
+			/* The reasoner will use the Restricted Chase by default. */
+			reasoner.reason();
+			System.out.println("After materialisation:");
+			for (final GraalConjunctiveQueryToRule graalConjunctiveQueryToRule : convertedConjunctiveQueries) {
+				ExamplesUtils.printOutQueryAnswers(graalConjunctiveQueryToRule.getQueryAtom(), reasoner);
+			}
+		}
+	}
+
+}

--- a/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/graal/AddDataFromDlgpFile.java
+++ b/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/graal/AddDataFromDlgpFile.java
@@ -1,5 +1,25 @@
 package org.semanticweb.vlog4j.examples.graal;
 
+/*-
+ * #%L
+ * VLog4j Examples
+ * %%
+ * Copyright (C) 2018 - 2019 VLog4j Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/graal/AddDataFromGraal.java
+++ b/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/graal/AddDataFromGraal.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.semanticweb.vlog4j.core.model.api.Atom;
+import org.semanticweb.vlog4j.core.model.api.Rule;
 import org.semanticweb.vlog4j.core.reasoner.Reasoner;
 import org.semanticweb.vlog4j.core.reasoner.exceptions.EdbIdbSeparationException;
 import org.semanticweb.vlog4j.core.reasoner.exceptions.IncompatiblePredicateArityException;
@@ -46,14 +46,13 @@ import fr.lirmm.graphik.graal.io.dlp.DlgpParser;
  * <p>
  * In VLog4J, the reasoner is queried by an Atom and the results are all facts
  * matching this Atom.<br>
- * In Graal, a query is a conjunction of atoms and a set of queried variables
- * from those atoms. The results are then all variable sets for which Atoms
- * matching the conjunction Atoms are found.
- * </p>
- * <p>
- * To apply a Graaal query to VLog4J, an additional Rule must be added to the
- * reasoner. This rule is part of the {@link ImportedGraalQuery}, which also
- * holds the query to use in {@link Reasoner#answerQuery(Atom, boolean)}.
+ * Answering a Graal ConjunctiveQuery over a certain knowledge base is
+ * equivalent to adding a {@link Rule} to the knowledge base, <em> prior to
+ * reasoning</em>. The rule consists of the query atoms as the body and a single
+ * atom with a new predicate containing all the answer variables of the query as
+ * the head. After the reasoning process, in which the rule is materialised, is
+ * completed, this rule head can then be used as a query atom to obtain the
+ * results of the Graal ConjunctiveQuery.
  * </p>
  * 
  * @author adrian

--- a/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/graal/AddDataFromGraal.java
+++ b/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/graal/AddDataFromGraal.java
@@ -1,0 +1,144 @@
+/**
+ * 
+ */
+package org.semanticweb.vlog4j.examples.graal;
+
+/*-
+ * #%L
+ * VLog4j Examples
+ * %%
+ * Copyright (C) 2018 VLog4j Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.semanticweb.vlog4j.core.model.api.Atom;
+import org.semanticweb.vlog4j.core.reasoner.Reasoner;
+import org.semanticweb.vlog4j.core.reasoner.exceptions.EdbIdbSeparationException;
+import org.semanticweb.vlog4j.core.reasoner.exceptions.IncompatiblePredicateArityException;
+import org.semanticweb.vlog4j.core.reasoner.exceptions.ReasonerStateException;
+import org.semanticweb.vlog4j.examples.ExamplesUtils;
+import org.semanticweb.vlog4j.graal.GraalConjunctiveQueryToRule;
+import org.semanticweb.vlog4j.graal.GraalToVLog4JModelConverter;
+
+import fr.lirmm.graphik.graal.io.dlp.DlgpParser;
+
+/**
+ * This example shows how facts and rules can be imported from objects of the
+ * Graal library. Special care must be taken with the import of Graal
+ * ConjunctiveQuery-objects, since unlike with VLog4J, they represent both the
+ * query atom and the corresponding rule.
+ * <p>
+ * In VLog4J, the reasoner is queried by an Atom and the results are all facts
+ * matching this Atom.<br>
+ * In Graal, a query is a conjunction of atoms and a set of queried variables
+ * from those atoms. The results are then all variable sets for which Atoms
+ * matching the conjunction Atoms are found.
+ * </p>
+ * <p>
+ * To apply a Graaal query to VLog4J, an additional Rule must be added to the
+ * reasoner. This rule is part of the {@link ImportedGraalQuery}, which also
+ * holds the query to use in {@link Reasoner#answerQuery(Atom, boolean)}.
+ * </p>
+ * 
+ * @author adrian
+ *
+ */
+public class AddDataFromGraal {
+
+	public static void main(final String[] args) throws ReasonerStateException, EdbIdbSeparationException, IncompatiblePredicateArityException, IOException {
+		/* 
+		 * 1. Instantiating rules 
+		 */
+		final List<fr.lirmm.graphik.graal.api.core.Rule> graalRules = new ArrayList<>();
+		
+		/* 
+		 * 1.1 Rules to map external database (EDB) predicates to internal database predicates (IDB).
+		 * Necessary because VLog4J requires separation between input predicates and predicates
+		 * for which additional facts can be derived.
+		 */
+		graalRules.add(DlgpParser.parseRule("bicycleIDB(X) :- bicycleEDB(X)."));
+		graalRules.add(DlgpParser.parseRule("wheelIDB(X) :- wheelEDB(X)."));
+		graalRules.add(DlgpParser.parseRule("hasPartIDB(X, Y) :- hasPartEDB(X, Y)."));
+		graalRules.add(DlgpParser.parseRule("isPartOfIDB(X, Y) :- isPartOfEDB(X, Y)."));
+		
+		/*
+		 * 1.2 Rules modelling that every bicycle has wheels and that the
+		 * has part relation is inverse to the is part of relation.
+		 */
+		graalRules.add(DlgpParser.parseRule("hasPartIDB(X, Y), wheelIDB(Y) :- bicycleIDB(X)."));
+		graalRules.add(DlgpParser.parseRule("isPartOfIDB(X, Y) :- wheelIDB(X)."));
+		graalRules.add(DlgpParser.parseRule("isPartOfIDB(X, Y) :- hasPartIDB(Y, X)."));
+		graalRules.add(DlgpParser.parseRule("hasPartIDB(X, Y) :- isPartOfIDB(Y, X)."));
+		
+		/**
+		 * 2. Instantiating Atoms representing the data to reason on (EDB).
+		 */
+		final List<fr.lirmm.graphik.graal.api.core.Atom> graalAtoms = new ArrayList<>();
+		
+		/*
+		 * bicycleEDB
+		 */
+		graalAtoms.add(DlgpParser.parseAtom("bicycleEDB(redBike)."));
+		graalAtoms.add(DlgpParser.parseAtom("bicycleEDB(blueBike)."));
+		graalAtoms.add(DlgpParser.parseAtom("bicycleEDB(blackBike)."));
+		
+		/*
+		 * wheelEDB
+		 */
+		graalAtoms.add(DlgpParser.parseAtom("wheelEDB(redWheel)."));
+		graalAtoms.add(DlgpParser.parseAtom("wheelEDB(blueWheel)."));
+		
+		/*
+		 * hasPartEDB
+		 */
+		graalAtoms.add(DlgpParser.parseAtom("hasPartEDB(redBike, redWheel)."));
+		graalAtoms.add(DlgpParser.parseAtom("hasPartEDB(blueBike, blueWheel)."));
+		
+		/*
+		 * 3. Instantiating a Graal conjunctive query. This is equivalent to adding the
+		 * rule query(?b, ?w) :- bicycleIDB(?b), wheelIDB(?w), isPartOfIDB(?w, ?b) and
+		 * then querying with query(?b, ?w) The rule from convertedGraalConjunctiveQuery
+		 * needs to be added to the reasoner.
+		 */
+		final GraalConjunctiveQueryToRule convertedGraalConjunctiveQuery = GraalToVLog4JModelConverter.convertQuery(
+				"graalQuery",
+				DlgpParser.parseQuery("?(B, W) :- bicycleIDB(B), wheelIDB(W), isPartOfIDB(W, B)."));
+		
+		/* 
+		 * 4. Loading, reasoning, and querying while using try-with-resources to close the reasoner automatically. 
+		 */
+		try (Reasoner reasoner = Reasoner.getInstance()) {
+			reasoner.addRules(GraalToVLog4JModelConverter.convertRules(graalRules));
+			reasoner.addRules(convertedGraalConjunctiveQuery.getRule());
+			reasoner.addFacts(GraalToVLog4JModelConverter.convertAtoms(graalAtoms));
+			
+			reasoner.load();
+			System.out.println("Before materialisation:");
+			ExamplesUtils.printOutQueryAnswers(convertedGraalConjunctiveQuery.getQueryAtom(), reasoner);
+
+			/* The reasoner will use the Restricted Chase by default. */
+			reasoner.reason();
+			System.out.println("After materialisation:");
+			ExamplesUtils.printOutQueryAnswers(convertedGraalConjunctiveQuery.getQueryAtom(), reasoner);
+			
+		}
+		
+	}
+
+}

--- a/vlog4j-graal/pom.xml
+++ b/vlog4j-graal/pom.xml
@@ -19,12 +19,12 @@
 		<dependency>
 			<groupId>fr.lirmm.graphik</groupId>
 			<artifactId>graal-api</artifactId>
-			<version>1.3.1</version>
+			<version>${graal.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>fr.lirmm.graphik</groupId>
 			<artifactId>graal-core</artifactId>
-			<version>1.3.1</version>
+			<version>${graal.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Added two examples showing how to convert from Graal Model objects to VLog4J objects. See [issue 64](https://github.com/knowsys/vlog4j/issues/64) for more details.