### PR TITLE
Enable proper logging in Java for the examples

### DIFF
--- a/vlog4j-examples/pom.xml
+++ b/vlog4j-examples/pom.xml
@@ -37,6 +37,11 @@
 			<artifactId>vlog4j-graal</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency> 
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
 		
 		<dependency>
 			<!-- Rio parser and writer implementation for the Turtle file format. -->

--- a/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/DoidExample.java
+++ b/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/DoidExample.java
@@ -59,6 +59,8 @@ public class DoidExample {
 	public static void main(final String[] args)
 			throws ReasonerStateException, IOException, EdbIdbSeparationException, IncompatiblePredicateArityException {
 
+		ExamplesUtils.configureLogging();
+
 		final URL wikidataSparqlEndpoint = new URL("https://query.wikidata.org/sparql");
 
 		try (final Reasoner reasoner = Reasoner.getInstance()) {

--- a/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/ExamplesUtils.java
+++ b/vlog4j-examples/src/main/java/org/semanticweb/vlog4j/examples/ExamplesUtils.java
@@ -1,5 +1,25 @@
 package org.semanticweb.vlog4j.examples;
 
+/*-
+ * #%L
+ * VLog4j Examples
+ * %%
+ * Copyright (C) 2018 - 2019 VLog4j Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import static org.semanticweb.vlog4j.core.model.implementation.Expressions.makeVariable;
 
 import java.io.IOException;
@@ -7,6 +27,10 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.log4j.ConsoleAppender;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
 import org.semanticweb.vlog4j.core.model.api.PositiveLiteral;
 import org.semanticweb.vlog4j.core.model.api.Term;
 import org.semanticweb.vlog4j.core.model.implementation.Expressions;
@@ -30,11 +54,39 @@ public final class ExamplesUtils {
 	}
 
 	/**
+	 * Defines how messages should be logged. This method can be modified to
+	 * restrict the logging messages that are shown on the console or to change
+	 * their formatting. See the documentation of Log4J for details on how to do
+	 * this.
+	 * 
+	 * Note: The VLog C++ backend performs its own logging. The log-level for this
+	 * can be configured using
+	 * {@link Reasoner#setLogLevel(org.semanticweb.vlog4j.core.reasoner.LogLevel)}.
+	 * It is also possible to specify a separate log file for this part of the logs.
+	 */
+	public static void configureLogging() {
+		// Create the appender that will write log messages to the console.
+		ConsoleAppender consoleAppender = new ConsoleAppender();
+		// Define the pattern of log messages.
+		// Insert the string "%c{1}:%L" to also show class name and line.
+		String pattern = "%d{yyyy-MM-dd HH:mm:ss} %-5p - %m%n";
+		consoleAppender.setLayout(new PatternLayout(pattern));
+		// Change to Level.ERROR for fewer messages:
+		consoleAppender.setThreshold(Level.INFO);
+
+		consoleAppender.activateOptions();
+		Logger.getRootLogger().addAppender(consoleAppender);
+	}
+
+	/**
 	 * Prints out the {@code reasoner} answer's to given query ({@code queryAtom}).
 	 *
-	 * @param queryAtom query to be answered
-	 * @param reasoner  reasoner to query on
-	 * @throws ReasonerStateException in case the reasoner has not yet been loaded.
+	 * @param queryAtom
+	 *            query to be answered
+	 * @param reasoner
+	 *            reasoner to query on
+	 * @throws ReasonerStateException
+	 *             in case the reasoner has not yet been loaded.
 	 */
 	public static void printOutQueryAnswers(final PositiveLiteral queryAtom, final Reasoner reasoner)
 			throws ReasonerStateException {
@@ -48,7 +100,8 @@ public final class ExamplesUtils {
 	/**
 	 * Returns the size of an Iterator
 	 *
-	 * @param Iterator<T> to iterate over
+	 * @param Iterator<T>
+	 *            to iterate over
 	 */
 	public static <T> int iteratorSize(Iterator<T> iterator) {
 		int size = 0;
@@ -60,8 +113,10 @@ public final class ExamplesUtils {
 	/**
 	 * Creates an Atom with @numberOfVariables distinct variables
 	 *
-	 * @param predicateName for the new predicate
-	 * @param arity     number of variables
+	 * @param predicateName
+	 *            for the new predicate
+	 * @param arity
+	 *            number of variables
 	 */
 	private static PositiveLiteral makeQueryAtom(String predicateName, int arity) {
 		final List<Term> vars = new ArrayList<>();
@@ -73,9 +128,12 @@ public final class ExamplesUtils {
 	/**
 	 * Exports the extension of the Atom with name @predicateName
 	 *
-	 * @param reasoner reasoner to query on
-	 * @param atomName atom's name
-	 * @param arity    atom's arity
+	 * @param reasoner
+	 *            reasoner to query on
+	 * @param atomName
+	 *            atom's name
+	 * @param arity
+	 *            atom's arity
 	 */
 	public static void exportQueryAnswersToCSV(Reasoner reasoner, String atomName, int arity)
 			throws ReasonerStateException, IOException {


### PR DESCRIPTION
Configure Java-side logging properly for the examples. This requires another dependency that selects the desired logger, so is not done by default, but it should be shown to people who want to see how to implement applications.