### PR TITLE
Remove pointy brackets in graal converter

### DIFF
--- a/vlog4j-graal/src/main/java/org/semanticweb/vlog4j/graal/GraalToVLog4JModelConverter.java
+++ b/vlog4j-graal/src/main/java/org/semanticweb/vlog4j/graal/GraalToVLog4JModelConverter.java
@@ -257,12 +257,7 @@ public final class GraalToVLog4JModelConverter {
 	private static Term convertTerm(final fr.lirmm.graphik.graal.api.core.Term term) {
 		final String id = term.getIdentifier().toString();
 		if (term.isConstant()) {
-			if (term.isLiteral()) {
-				return makeConstant(id);
-			} else {
-				// Add < > manually to match VLog's IRIs
-				return makeConstant("<" + id + ">");
-			}
+			return makeConstant(id);
 		} else if (term.isVariable()) {
 			return makeVariable(id);
 		} else {

--- a/vlog4j-graal/src/test/java/org/semanticweb/vlog4j/graal/GraalToVLog4JModelConverterTest.java
+++ b/vlog4j-graal/src/test/java/org/semanticweb/vlog4j/graal/GraalToVLog4JModelConverterTest.java
@@ -67,7 +67,7 @@ public class GraalToVLog4JModelConverterTest {
 	private final String y = "Y";
 	private final String z = "Z";
 
-	private final Constant vlog4j_socrate = makeConstant("<" + this.socrate + ">");
+	private final Constant vlog4j_socrate = makeConstant(this.socrate);
 
 	private final Predicate vlog4j_bicycle = makePredicate(this.bicycle, 1);
 	private final Predicate vlog4j_hasPart = makePredicate(this.hasPart, 2);
@@ -215,7 +215,7 @@ public class GraalToVLog4JModelConverterTest {
 		final PositiveLiteral vlog4j_predicate2_atom = makePositiveLiteral(makePredicate(predicate2, 2), this.vlog4j_y,
 				this.vlog4j_x);
 		final PositiveLiteral vlog4j_predicate3_atom = makePositiveLiteral(makePredicate(predicate3, 2), this.vlog4j_y,
-				makeConstant("<" + stockholm + ">"));
+				makeConstant(stockholm));
 		final PositiveLiteral vlog4j_predicate4_atom = makePositiveLiteral(makePredicate(predicate4, 3), this.vlog4j_x,
 				this.vlog4j_y, this.vlog4j_z);
 		final Rule expectedComplexQueryRule = makeRule(expectedComplexQueryAtom, vlog4j_predicate1_atom,


### PR DESCRIPTION
Because of our new parser generator, we don't need to add "<" and ">" in graal module